### PR TITLE
Release v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-permalinks",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A plugin for Strapi CMS to enable permalinks for content types with nested relationships.",
   "license": "MIT",
   "strapi": {

--- a/server/bootstrap/index.js
+++ b/server/bootstrap/index.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const transformApiResponseMiddleware = require( '../middlewares/transform-api-response' );
 const lifecycleBeforeUpdate = require( './lifecycle-before-update' );
 const schemaValidation = require( './schema-validation' );
 
 module.exports = async params => {
+  await transformApiResponseMiddleware( params );
   await schemaValidation( params );
   await lifecycleBeforeUpdate( params );
 };

--- a/server/bootstrap/lifecycle-before-update.js
+++ b/server/bootstrap/lifecycle-before-update.js
@@ -3,8 +3,9 @@
 const { getService } = require( '../utils' );
 
 module.exports = async ( { strapi } ) => {
+  const configService = getService( 'config' );
   const pluginService = getService( 'permalinks' );
-  const { contentTypes } = await pluginService.getConfig();
+  const { contentTypes } = await configService.get();
   const models = contentTypes.map( type => type.uid );
 
   // Lifecycle hook to sync descendants before a parent relation changes.

--- a/server/bootstrap/schema-validation.js
+++ b/server/bootstrap/schema-validation.js
@@ -5,7 +5,7 @@ const { ValidationError } = require( '@strapi/utils' ).errors;
 const { getService } = require( '../utils' );
 
 module.exports = async ( { strapi } ) => {
-  const { contentTypes } = await getService( 'permalinks' ).getConfig();
+  const { contentTypes } = await getService( 'config' ).get();
 
   contentTypes.forEach( type => {
     const model = strapi.db.metadata.get( type.uid );

--- a/server/controllers/permalinks.js
+++ b/server/controllers/permalinks.js
@@ -6,7 +6,7 @@ const { getService, pluginId } = require( '../utils' );
 
 module.exports = {
   async config( ctx ) {
-    const { contentTypes } = await getService( 'permalinks' ).getConfig();
+    const { contentTypes } = await getService( 'config' ).get();
 
     const config = {
       contentTypes,
@@ -17,8 +17,9 @@ module.exports = {
 
   async ancestorsPath( ctx ) {
     const { uid, id, parentId, value } = ctx.request.body;
+    const configService = getService( 'config' );
     const pluginService = getService( 'permalinks' );
-    const { contentTypes } = await pluginService.getConfig();
+    const { contentTypes } = await configService.get();
     const supportedType = contentTypes.find( type => type.uid === uid );
 
     if ( ! supportedType ) {

--- a/server/middlewares/transform-api-response.js
+++ b/server/middlewares/transform-api-response.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { get, has, head, isArray } = require( 'lodash' );
+
+const { getService, isApiRequest } = require( '../utils' );
+
+// Transform function which is used to transform the response object.
+const transform = ( data, field ) => {
+  // Single entry.
+  if ( has( data, 'attributes' ) ) {
+    return transform( data.attributes, field );
+  }
+
+  // Collection of entries.
+  if ( isArray( data ) && data.length && has( head( data ), 'attributes' ) ) {
+    return data.map( item => transform( item, field ) );
+  }
+
+  // Replace ~ with / in slug fields.
+  data[ field ] = data[ field ].replace( '~', '/' );
+
+  return data;
+};
+
+// Transform API response by parsing data string to JSON for rich text fields.
+module.exports = ( { strapi } ) => {
+  strapi.server.use( async ( ctx, next ) => {
+    const config = await getService( 'config' ).get();
+
+    await next();
+
+    if ( ! ctx.body || ! config.contentTypes ) {
+      return;
+    }
+
+    // Determine if this request should transform the data response.
+    const { handler } = ctx.state.route;
+    const contentType = config.contentTypes.find( ( { uid } ) => handler.includes( uid ) );
+    const shouldTransform = ctx.body.data && isApiRequest( ctx ) && !! contentType;
+
+    if ( shouldTransform ) {
+      ctx.body.data = transform( ctx.body.data, contentType.targetField );
+    }
+  } );
+};

--- a/server/middlewares/transform-api-response.js
+++ b/server/middlewares/transform-api-response.js
@@ -17,7 +17,7 @@ const transform = ( data, config ) => {
   }
 
   // Replace ~ with / in data's `targetField`.
-  data[ config.targetField ] = data[ config.targetField ].replace( '~', '/' );
+  data[ config.targetField ] = data[ config.targetField ].replaceAll( '~', '/' );
 
   const relationTargetField = `${config.targetRelation}.${config.targetField}`;
 
@@ -26,7 +26,7 @@ const transform = ( data, config ) => {
     set(
       data,
       relationTargetField,
-      get( data, relationTargetField ).replace( '~', '/' )
+      get( data, relationTargetField ).replaceAll( '~', '/' )
     );
   }
 

--- a/server/services/config.js
+++ b/server/services/config.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const config = require( '../config' );
+const { pluginId } = require( '../utils' );
+
+module.exports = ( { strapi } ) => ( {
+  async get() {
+    const data = await strapi.config.get( `plugin.${pluginId}`, config.default );
+
+    return data;
+  },
+} );

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const config = require( './config' );
 const permalinks = require( './permalinks' );
 
 module.exports = {
+  'config': config,
   'permalinks': permalinks,
 };

--- a/server/services/permalinks.js
+++ b/server/services/permalinks.js
@@ -26,12 +26,6 @@ module.exports = ( { strapi } ) => ( {
     return false;
   },
 
-  async getConfig() {
-    const data = await strapi.config.get( `plugin.${pluginId}`, config.default );
-
-    return data;
-  },
-
   async syncChildren( uid, id, value, options ) {
     const { targetField, targetRelation } = options;
 

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -2,10 +2,12 @@
 
 const getPermalinkSlug = require( './get-permalink-slug' );
 const getService = require( './get-service' );
+const isApiRequest = require( './is-api-request' );
 const pluginId = require( './plugin-id' );
 
 module.exports = {
   getPermalinkSlug,
   getService,
+  isApiRequest,
   pluginId,
 };

--- a/server/utils/is-api-request.js
+++ b/server/utils/is-api-request.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const isApiRequest = ctx => (
+  ctx.state &&
+  ctx.state.route &&
+  ctx.state.route.info &&
+  ctx.state.route.info.type === 'content-api'
+);
+
+module.exports = isApiRequest;


### PR DESCRIPTION
# Included in this release

* Middleware to replace `~` with `/` in public API responses.