### PR TITLE
Create getApiUrl util

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Matt Milburn
+Copyright (c) 2023 Matt Milburn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/admin/src/components/PermalinkInput/index.js
+++ b/admin/src/components/PermalinkInput/index.js
@@ -15,6 +15,7 @@ import { PATH_SEPARATOR, UID_REGEX } from '../../constants';
 import { useDebounce } from '../../hooks';
 import {
   axiosInstance,
+  getApiUrl,
   getPermalink,
   getPermalinkAncestors,
   getPermalinkSlug,
@@ -103,7 +104,7 @@ const PermalinkInput = ( {
     try {
       const newSlug = getPermalink( isOrphan ? null : ancestorsPath, slug, lowercase );
       const params = `${contentTypeUID}/${newSlug}`;
-      const endpoint = `${pluginId}/check-availability/${params}`;
+      const endpoint = getApiUrl( `${pluginId}/check-availability/${params}` );
 
       const { data } = await axiosInstance.get( endpoint );
 
@@ -131,7 +132,7 @@ const PermalinkInput = ( {
 
     try {
       const params = `${contentTypeUID}/${modifiedData.id}`;
-      const endpoint = `${pluginId}/check-connection/${params}`;
+      const endpoint = getApiUrl( `${pluginId}/check-connection/${params}` );
 
       const {
         data: {
@@ -244,7 +245,7 @@ const PermalinkInput = ( {
       const params = isCreatingEntry
         ? `${contentTypeUID}/${targetRelationValue.id}`
         : `${contentTypeUID}/${modifiedData.id}/${targetRelationValue.id}/${initialSlug}`;
-      const endpoint = `${pluginId}/ancestors-path/${params}`;
+      const endpoint = getApiUrl( `${pluginId}/ancestors-path/${params}` );
 
       const {
         data: {
@@ -287,7 +288,7 @@ const PermalinkInput = ( {
 
     try {
       const params = `${contentTypeUID}/${debouncedTargetValue}`;
-      const endpoint = `${pluginId}/suggestion/${params}`;
+      const endpoint = getApiUrl( `${pluginId}/suggestion/${params}` );
 
       const {
         data: {

--- a/admin/src/utils/get-api-url.js
+++ b/admin/src/utils/get-api-url.js
@@ -1,0 +1,9 @@
+const getApiUrl = path => {
+  if ( ! window ) {
+    return path;
+  }
+
+  return `${window.location.protocol}//${window.location.host}/${path}`;
+};
+
+export default getApiUrl;

--- a/admin/src/utils/index.js
+++ b/admin/src/utils/index.js
@@ -1,4 +1,5 @@
 export { default as axiosInstance } from './axios-instance';
+export { default as getApiUrl } from './get-api-url';
 export { default as getPermalink } from './get-permalink';
 export { default as getPermalinkAncestors } from './get-permalink-ancestors';
 export { default as getPermalinkSlug } from './get-permalink-slug';


### PR DESCRIPTION
This util helps fix a bug where absolute URLs are used for fetch requests if running Strapi with `yarn develop` vs `yarn develop --watch-admin`, which allows relative URLs in fetch requests.