### PR TITLE
Use backendURL for getApiUrl util

### DIFF
--- a/admin/src/utils/get-api-url.js
+++ b/admin/src/utils/get-api-url.js
@@ -1,9 +1,3 @@
-const getApiUrl = path => {
-  if ( ! window ) {
-    return path;
-  }
-
-  return `${window.location.protocol}//${window.location.host}/${path}`;
-};
+const getApiUrl = path => `${strapi.backendURL}/${path}`;
 
 export default getApiUrl;


### PR DESCRIPTION
This fixes a mistake made with `getApiUrl` where `window.location` was being used instead of `strapi.backendURL`.