### PR TITLE
Use pluginOptions for attribute customization

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,6 +13,33 @@ Previously, the plugin was using a custom `uid` field to manage the permalink va
 
 > Nothing should be required to accommodate this update in your app.
 
+### Use `pluginOptions` for attribute configuration
+Previously, the `targetField` and `targetRelation` props were added directly to a model attribute. Going forward, those props will need to be added to the `pluginOptions.permalinks` prop for a model attribute. See example below.
+
+```js
+// Incorrect.
+"slug": {
+  "type": "customField",
+  "customField": "plugin::permalinks.permalink",
+  "targetField": "title",
+  "targetRelation": "parent",
+  "required": true
+},
+
+// Correct.
+"slug": {
+  "type": "customField",
+  "customField": "plugin::permalinks.permalink",
+  "required": true,
+  "pluginOptions": {
+    "permalinks": {
+      "targetField": "title",
+      "targetRelation": "parent"
+    }
+  }
+},
+```
+
 ### Remove tilde characters (~) from permalinks
 Because the plugin was previously using a `uid` field, the slash `/` characters were not allowed to be used. Instead, the tilde `~` character was sacrificed as a replacement for slashes to allow the value to validate properly according to the database schema.
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ After adding a permalink field through the content type builder, there are addit
     "slug": {
       "type": "customField",
       "customField": "plugin::permalinks.permalink",
-      "targetField": "title",
-      "targetRelation": "parent",
-      "required": true
+      "required": true,
+      "pluginOptions": {
+        "permalinks": {
+          "targetField": "title",
+          "targetRelation": "parent"
+        }
+      }
     },
     "content": {
       "type": "richtext"

--- a/admin/src/contentManagerHooks/filter-permalink-columns.js
+++ b/admin/src/contentManagerHooks/filter-permalink-columns.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import { Typography } from '@strapi/design-system/Typography';
 
 import { ListViewTableCell  } from '../components';
@@ -20,8 +21,9 @@ const filterPermalinkColumns = ( { displayedHeaders, layout } ) => {
         const ancestorsPath = getPermalinkAncestors( value );
         const slug = getPermalinkSlug( value );
 
-        // Check if this entity has been orphaned due to its parent being deleted.
-        const targetRelationValue = props[ header.fieldSchema.targetRelation ];
+        // Check if this entity has been orphaned due to a broken parent connection.
+        const targetRelationName = get( header, [ 'fieldSchema', 'pluginOptions', pluginId, 'targetRelation' ] );
+        const targetRelationValue = get( props, targetRelationName );
         const isOrphan = !! ancestorsPath && ! targetRelationValue;
 
         return (

--- a/server/utils/get-permalink-attr.js
+++ b/server/utils/get-permalink-attr.js
@@ -2,6 +2,8 @@
 
 const get = require( 'lodash/get' );
 
+const pluginId = require( './plugin-id' );
+
 const getPermalinkAttr = uid => {
   const model = strapi.getModel( uid );
 
@@ -14,13 +16,14 @@ const getPermalinkAttr = uid => {
   }
 
   const [ name, attr ] = permalinkAttr;
-  const relationUID = get( model, [ 'attributes', attr.targetRelation, 'target' ] );
+  const { targetField, targetRelation } = get( attr, [ 'pluginOptions', pluginId ] );
+  const targetRelationUID = get( model, [ 'attributes', targetRelation, 'target' ] );
 
   return {
     name,
-    targetField: attr.targetField,
-    targetRelation: attr.targetRelation,
-    targetRelationUID: relationUID,
+    targetField,
+    targetRelation,
+    targetRelationUID,
   };
 };
 


### PR DESCRIPTION
Per Strapi standards, the `targetField` and `targetRelation` props are being moved into the `pluginOptions` prop for model attributes.