### PR TITLE
Parse API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use the "Custom" tab in the content type builder to add the permalink field to t
 
 After adding a permalink field through the content type builder, there are additional `targetField` and `targetRelation` props that will need to be manually added to the permalink schema attribute.
 
-> **NOTE:** Strapi does not currently provide the necessary params to dynamically render a list containing the other field names as select menu options in the content type builder, which is why `targetField` and `targetRelation` need to be added manually for now.
+> **NOTE:** Strapi does not currently provide the necessary params to dynamically render a list containing the other field names as select menu options in the content type builder, which is why `targetField` and `targetRelation` need to be added manually for now. This will be updated in the future.
 
 #### Schema for `Page`
 ```js
@@ -115,7 +115,7 @@ Let's add our `Page` content type to the plugin config, which will enable it in 
 'use strict';
 
 module.exports = {
-  'permalinks': {
+  permalinks: {
     config: {
       contentTypes: [
         {
@@ -137,7 +137,7 @@ We will want to keep them all in sync with unique permalinks. Our config might l
 'use strict';
 
 module.exports = {
-  'permalinks': {
+  permalinks: {
     config: {
       contentTypes: [
         {
@@ -173,7 +173,7 @@ In order to use the full permalink URL for the "Copy permalink" feature or to us
 'use strict';
 
 module.exports = ( { env } ) => ( {
-  'permalinks': {
+  permalinks: {
     config: {
       contentTypes: [
         {
@@ -193,17 +193,57 @@ module.exports = ( { env } ) => ( {
 } );
 ```
 
+#### Example with localization
+
+With `i18n` enabled for the `slug` field, you can insert the `locale` into the permalink value using the `url` config option.
+
+> Currently this does not keep the locale with the value in the database. In a future release, a change may be introduced where the locale value is optionally saved with the slug value in the database.
+
+```js
+// config/plugins.js
+'use strict';
+
+module.exports = ( { env } ) => ( {
+  permalinks: {
+    config: {
+      contentTypes: [
+        // Include `locale` in the localized slug.
+        {
+          uids: [
+            'api::page.page',
+            'api::product-page.product-page',
+          ],
+          url: '{locale}/{slug}',
+        },
+
+        // Example with localized absolute URL and env vars.
+        {
+          uids: [ 'api::help-page.help-page' ],
+          url: `${env( 'STRAPI_PERMALINKS_BASE_URL' )}/{locale}/help/{slug}`,
+        },
+
+        // Another example with a different locale position.
+        {
+          uids: [ 'api::example.example' ],
+          url: 'https://{locale}.example.com/{slug}',
+        },
+      ],
+    },
+  },
+} );
+```
+
 > Notice how the `HelpPage` example has `/help/` prepending it's slug value, which already makes it unique against `Page` and `ProductPage`.
 
 #### Mapping values from entry data into permalink URLs
-By using `{curly_braces}`, you can map values from the entry data into your permalink URLs to customize the URL however you like.
+By using `{curly_braces}`, you can map values from the entry data into your permalink URLs to customize the URL however you like. Unmatched values will be replaced with an empty string.
 
-> **Unmatched values** will be replaced with an empty string.
+> **Relation fields** are not currently supported but that will change in a future update which will allow the `url` option to use something like `{category.slug}` to inject a category slug into the path.
 
 ```js
 {
   uids: [ 'api::product-page.product-page' ],
-  url: `${env( 'STRAPI_PERMALINKS_BASE_URL' )}/{category}/{slug}`,
+  url: `${env( 'STRAPI_PERMALINKS_BASE_URL' )}/{locale}/{slug}`,
 }
 ```
 
@@ -228,7 +268,7 @@ Defaults to `true`. It will ensure the permalink value is always lowercased.
 'use strict';
 
 module.exports = ( { env } ) => ( {
-  'permalinks': {
+  permalinks: {
     config: {
       lowercase: false,
       contentTypes: [
@@ -294,8 +334,9 @@ yarn develop
 If you are enjoying this plugin and feel extra appreciative, you can [buy me a beer or 3 🍺🍺🍺](https://www.buymeacoffee.com/mattmilburn).
 
 ## <a id="roadmap"></a>🚧 Roadmap
-* Config option to prevent using reserved slugs
-* Config option to limit nesting depth
-* Better conflict resolution for orphaned pages
-* Better method for handling complicated localized URLs (currently requires plugin with custom hook and middleware)
-* Use same content-type builder options as `uid` field, then deprecate it in plugin config (not currently possible)
+* Better support for localization and relation field data populating into the URL.
+* Config option to prevent using reserved slugs.
+* Config option to limit nesting depth.
+* Better conflict resolution for orphaned pages.
+* Better method for handling complicated localized URLs (currently requires plugin with custom hook and middleware).
+* Use same content-type builder options as `uid` field, then deprecate it in plugin config (not currently possible).

--- a/admin/src/components/PermalinkInput/index.js
+++ b/admin/src/components/PermalinkInput/index.js
@@ -134,6 +134,12 @@ const PermalinkInput = ({
 
     try {
       const newSlug = getPermalink(isOrphan ? null : ancestorsPath, slug, lowercase);
+
+      if (!newSlug) {
+        setIsLoading(false);
+        return;
+      }
+
       const params = `${contentTypeUID}/${encodeURIComponent(newSlug)}`;
       const endpoint = getApiUrl(`${pluginId}/check-availability/${params}`);
 

--- a/admin/src/hooks/use-plugin-config.js
+++ b/admin/src/hooks/use-plugin-config.js
@@ -27,7 +27,6 @@ const usePluginConfig = () => {
       })
       .catch((err) => {
         if ('code' in err && err?.code === 'ERR_CANCELED') {
-          console.log('CANCELLED', err);
           return;
         }
 

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -1,11 +1,15 @@
 'use strict';
 
 const { afterUpdate, beforeCreateUpdate } = require('./lifecycles');
+const { transformPermalinks } = require('./middlewares');
 const { getService } = require('./utils');
 
 module.exports = async (params) => {
   // Startup validation.
   await getService('validation').validateSchema(params);
+
+  // Middlewares.
+  await transformPermalinks(params);
 
   // Lifecycles.
   await beforeCreateUpdate(params);

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const transformPermalinks = require('./transform-permalinks');
+
+module.exports = {
+  transformPermalinks,
+};

--- a/server/middlewares/transform-permalinks.js
+++ b/server/middlewares/transform-permalinks.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const get = require('lodash/get');
 const has = require('lodash/has');
 const head = require('lodash/head');
 const omit = require('lodash/omit');
@@ -52,7 +51,11 @@ const transform = (data, uid, config) => {
 
   // Transform permalink field.
   if (has(data, name)) {
-    data[name] = parseUrl(uidConfig, data);
+    const parsedValue = parseUrl(uidConfig, data);
+
+    if (parsedValue) {
+      data[name] = parsedValue;
+    }
   }
 
   // Transform target relation field.

--- a/server/middlewares/transform-permalinks.js
+++ b/server/middlewares/transform-permalinks.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const get = require('lodash/get');
+const has = require('lodash/has');
+const head = require('lodash/head');
+const omit = require('lodash/omit');
+
+const { getService, isApiRequest, parseUrl } = require('../utils');
+
+// Transform function used to transform the response object.
+const transform = (data, uid, config) => {
+  if (!data) {
+    return data;
+  }
+
+  // Entity or relation wrapper.
+  if (has(data, 'data')) {
+    return {
+      ...data,
+      data: transform(data.data, uid, config),
+    };
+  }
+
+  // Entity or relation data.
+  if (has(data, 'attributes')) {
+    return {
+      ...data,
+      attributes: transform(data.attributes, uid, config),
+    };
+  }
+
+  // Support strapi-plugin-transformer features which might remove `attributes`
+  // and `data` wrappers.
+  if (has(data, 'id')) {
+    return {
+      ...data,
+      // Must omit the id otherwise it creates an infinite loop.
+      ...transform(omit(data, 'id'), uid, config),
+    };
+  }
+
+  // Collection of entities, relations, or components.
+  if (
+    Array.isArray(data) &&
+    (has(head(data), 'attributes') || has(head(data), 'id') || has(head(data), '__component'))
+  ) {
+    return data.map((item) => transform(item, uid, config));
+  }
+
+  const uidConfig = config.contentTypes.find(item => item.uids.includes(uid));
+  const { name, targetRelation, targetRelationUID } = config.layouts[uid];
+
+  // Transform permalink field.
+  if (has(data, name)) {
+    data[name] = parseUrl(uidConfig, data);
+  }
+
+  // Transform target relation field.
+  if (has(data, targetRelation)) {
+    data[targetRelation] = transform(data[targetRelation], targetRelationUID, config);
+  }
+
+  // Transform localizations array.
+  if (has(data, 'localizations')) {
+    data.localizations = data.localizations.map((item) => transform(item, uid, config));
+  }
+
+  return data;
+};
+
+// Transform API response.
+module.exports = ({ strapi }) => {
+  strapi.server.use(async (ctx, next) => {
+    await next();
+
+    if (!ctx.body || !ctx.body.data || !isApiRequest(ctx)) {
+      return;
+    }
+
+    // Determine if this request should transform the data response.
+    const { contentTypes } = await getService('config').get();
+    const layouts = await getService('config').layouts();
+    const uids = await getService('config').uids();
+    const uid = uids.find(_uid => ctx.state.route.handler.includes(_uid));
+
+    if (!uid) {
+      return;
+    }
+
+    const config = { contentTypes, layouts };
+
+    ctx.body.data = transform(ctx.body.data, uid, config);
+  });
+};

--- a/server/utils/__tests__/parse-url.spec.js
+++ b/server/utils/__tests__/parse-url.spec.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const parseUrl = require('../parse-url');
+
+describe('parseUrl', () => {
+  it('should do nothing if no `url` prop is set', () => {
+    const config = {};
+    const data = {};
+    const result = parseUrl(config, data);
+
+    expect(result).toBeNull();
+  });
+
+  it('should build a url from config settings', () => {
+    const config = { url: 'https://www.example.com/{slug}' };
+    const data = { slug: 'foobar' };
+    const output = 'https://www.example.com/foobar';
+    const result = parseUrl(config, data);
+
+    expect(result).toEqual(output);
+  });
+});

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -7,6 +7,7 @@ const getService = require('./get-service');
 const interpolate = require('./interpolate');
 const isApiRequest = require('./is-api-request');
 const isConnecting = require('./is-connecting');
+const parseUrl = require('./parse-url');
 const pluginId = require('./plugin-id');
 const trimSlashes = require('./trim-slashes');
 
@@ -18,6 +19,7 @@ module.exports = {
   interpolate,
   isApiRequest,
   isConnecting,
+  parseUrl,
   pluginId,
   trimSlashes,
 };

--- a/server/utils/parse-url.js
+++ b/server/utils/parse-url.js
@@ -4,7 +4,7 @@ const interpolate = require('./interpolate');
 const trimSlashes = require('./trim-slashes');
 
 const parseUrl = (config, data) => {
-  if (!config?.url || !data) {
+  if (!config.url || !data) {
     return null;
   }
 

--- a/server/utils/parse-url.js
+++ b/server/utils/parse-url.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const interpolate = require('./interpolate');
+const trimSlashes = require('./trim-slashes');
+
+const parseUrl = (config, data) => {
+  if (!config?.url || !data) {
+    return null;
+  }
+
+  const supportedTypes = ['number', 'string'];
+  const replacements = Object.entries(data).reduce((acc, [key, val]) => {
+    if (!supportedTypes.includes(typeof val)) {
+      return acc;
+    }
+
+    return {
+      ...acc,
+      [key]: val,
+    };
+  }, {});
+
+  const url = interpolate(trimSlashes(config.url), replacements);
+
+  return url;
+};
+
+module.exports = parseUrl;


### PR DESCRIPTION
Fixes an issue where API responses were not applying the `url` config option to the permalink.

**In a future release**, this will be refactored so things like localization, relation properties, and full permalinks will be easier/possible to work with.